### PR TITLE
:sparkles: feature to rename/save_as file

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,5 +6,4 @@ pub const HELP: &str = "help";
 pub const OPEN: &str = "open";
 pub const NEW: &str = "new";
 pub const SAVE: &str = "w";
-pub const SAVE_AS: &str = "w";
 pub const SAVE_AND_QUIT: &str = "wq";

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,4 +6,5 @@ pub const HELP: &str = "help";
 pub const OPEN: &str = "open";
 pub const NEW: &str = "new";
 pub const SAVE: &str = "w";
+pub const SAVE_AS: &str = "w";
 pub const SAVE_AND_QUIT: &str = "wq";

--- a/src/document.rs
+++ b/src/document.rs
@@ -101,7 +101,7 @@ impl Document {
     /// # Errors
     ///
     /// Can return an error if the file can't be created or written to.
-    pub fn save(&self) -> Result<(), Error> {
+    pub fn save(&self, new_name: &str) -> Result<(), Error> {
         if !self.filename.is_empty() {
             let mut file = fs::File::create(self.filename.as_str())?;
             for row in &self.rows {
@@ -111,17 +111,10 @@ impl Document {
             if fs::remove_file(Self::swap_filename(self.filename.as_str())).is_ok() {
                 // pass
             }
+            if !new_name.is_empty() {
+                fs::rename(self.filename.as_str(), new_name)?;
+            }
         }
-        Ok(())
-    }
-
-    /// # Errors
-    ///
-    /// Function to rename the name of the file
-    pub fn save_as(&self, new_name: &str) -> Result<(), Error> {
-        self.save()?;
-        fs::rename(self.filename.as_str(), new_name)?;
-
         Ok(())
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -115,6 +115,16 @@ impl Document {
         Ok(())
     }
 
+    /// # Errors
+    ///
+    /// Function to rename the name of the file
+    pub fn save_as(&self, new_name: &str) -> Result<(), Error> {
+        self.save()?;
+        fs::rename(self.filename.as_str(), new_name)?;
+
+        Ok(())
+    }
+
     #[must_use]
     pub fn get_row(&self, index: usize) -> Option<&Row> {
         self.rows.get(index)

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -244,6 +244,10 @@ impl Editor {
                             self.document = Document::new_empty(cmd_tokens[1].to_string());
                             self.enter_insert_mode();
                         }
+                        Some(&commands::SAVE_AS) => {
+                            let new_name = cmd_tokens[1];
+                            self.save_as(new_name);
+                        }
                         _ => (),
                     }
                 } else {
@@ -292,6 +296,25 @@ impl Editor {
             self.unsaved_edits = 0;
         } else {
             self.display_message(utils::red("Error writing to file!"));
+        }
+    }
+
+    fn save_as(&mut self, new_name: &str) {
+        self.document.trim_trailing_spaces();
+        if self.cursor_position.x >= self.current_row().len() {
+            self.cursor_position.x = self.current_row().len().saturating_sub(1);
+        }
+
+        if self.document.save_as(new_name).is_ok() {
+            let old_name = &self.document.filename.clone();
+            self.display_message(format!(
+                "{} successfully saved as {}",
+                old_name, new_name
+            ));
+            self.is_dirty = false;
+            self.unsaved_edits = 0;
+        } else {
+            self.display_message(utils::red("Error changing filename"));
         }
     }
 


### PR DESCRIPTION
Ability to change file name by post-fixing the new name at the end `:w new_name`

Closes #29  

# issues not addressed 
- have not implemented the white status bar to display the newly changed name
- not possible to use names with spaces between them
- Have not kept the code DRY in the editor module. Move the `save_as` function code to `save` and use conditional statements instead. 
