### PR TITLE
:sparkles: feature to rename/save_as file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ So, something like [Left](https://hundredrabbits.itch.io/left), but with vim-lik
 - [x] Create a new file
 - [x] Open an existing file
 - [x] Save file `w`
-- [ ] Rename file
+- [x] Rename file `w` `file name`
 - [x] Insert character under the cursor
 - [ ] block (word, paragraph, line, etc) with both `d` and `c`
 - [x] delete a line with `dd`

--- a/src/document.rs
+++ b/src/document.rs
@@ -111,7 +111,7 @@ impl Document {
     /// # Errors
     ///
     /// Can return an error if the file can't be created or written to.
-    pub fn save(&self) -> Result<(), Error> {
+    pub fn save(&self, new_name: &str) -> Result<(), Error> {
         if !self.filename.is_empty() {
             let mut file = fs::File::create(self.filename.as_str())?;
             for row in &self.rows {
@@ -120,6 +120,9 @@ impl Document {
             }
             if fs::remove_file(Self::swap_filename(self.filename.as_str())).is_ok() {
                 // pass
+            }
+            if !new_name.is_empty() {
+                fs::rename(self.filename.as_str(), new_name)?;
             }
         }
         Ok(())

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -952,7 +952,7 @@ impl Editor {
                             open <filename> => open a file\r\n  \
                             q               => quit bo\r\n  \
                             stats           => toggle line/word stats\r\n  \
-                            w               => save\r\n  \
+                            w    <new_name> => save\r\n  \
                             wq              => save and quit\r\n\n\
                         Insert commands\r\n  \
                             Esc => go back to normal mode";

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -246,6 +246,10 @@ impl Editor {
                             self.document = Document::new_empty(cmd_tokens[1].to_string());
                             self.enter_insert_mode();
                         }
+                        Some(&commands::SAVE) => {
+                            let new_name = cmd_tokens[1..].join(" ");
+                            self.save(new_name.as_str());
+                        }
                         _ => (),
                     }
                 } else {
@@ -267,9 +271,9 @@ impl Editor {
                         commands::HELP => {
                             self.alternate_screen = true;
                         }
-                        commands::SAVE => self.save(),
+                        commands::SAVE => self.save(""),
                         commands::SAVE_AND_QUIT => {
-                            self.save();
+                            self.save("");
                             self.quit(false);
                         }
                         _ => self
@@ -281,15 +285,19 @@ impl Editor {
         }
     }
 
-    fn save(&mut self) {
+    fn save(&mut self, new_name: &str) {
         // this will trim trailing spaces, which might cause the cursor to get out of bounds
         self.document.trim_trailing_spaces();
         if self.cursor_position.x >= self.current_row().len() {
             self.cursor_position.x = self.current_row().len().saturating_sub(1);
         }
 
-        if self.document.save().is_ok() {
-            self.display_message("File saved successfully".to_string());
+        if self.document.save(new_name).is_ok() {
+            if new_name.is_empty(){
+                self.display_message("File saved successfully".to_string());
+            } else {
+            self.display_message(format!("{} successfully renamed as {}", self.document.filename, new_name));
+            }
             self.unsaved_edits = 0;
             self.last_saved_hash = self.document.hashed();
         } else {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -248,7 +248,7 @@ impl Editor {
                         }
                         Some(&commands::SAVE) => {
                             let new_name = cmd_tokens[1..].join(" ");
-                            self.save(new_name.as_str());
+                            self.save(new_name.trim());
                         }
                         _ => (),
                     }
@@ -293,10 +293,14 @@ impl Editor {
         }
 
         if self.document.save(new_name).is_ok() {
-            if new_name.is_empty(){
+            if new_name.is_empty() {
                 self.display_message("File saved successfully".to_string());
             } else {
-            self.display_message(format!("{} successfully renamed as {}", self.document.filename, new_name));
+                self.display_message(format!(
+                    "{} successfully renamed as {}",
+                    self.document.filename, new_name
+                ));
+                self.document.filename = String::from(new_name);
             }
             self.unsaved_edits = 0;
             self.last_saved_hash = self.document.hashed();


### PR DESCRIPTION
Fixes #29
 
save_as rename now implemented from the save function