### PR TITLE
Restore cache post checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
     - uses: Swatinem/rust-cache@v1  # cache crate builds between CI builds to make them faster
-    - uses: actions/checkout@v2
     - name: clippy
       run:  cargo clippy --all-targets --all-features -- -D warnings
 
@@ -28,12 +28,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
     - uses: Swatinem/rust-cache@v1  # cache crate builds between CI builds to make them faster
-    - uses: actions/checkout@v2
     - name: Build
       run: cargo build
     - name: Run tests


### PR DESCRIPTION
The `checkout` action displays the following message

```
Deleting the contents of '/home/runner/work/bo/bo'
```

meaning that I should probably use the caching actions _after_.
