### PR TITLE
Fix clippy violations

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -35,7 +35,6 @@ impl Row {
         format!("{}{}", prefix, visible)
     }
 
-    #[must_use]
     pub fn chars(&self) -> std::str::Chars {
         self.string.chars()
     }
@@ -124,6 +123,7 @@ impl Row {
         self.string = format!("{}{}", self.string, other.string);
     }
 
+    #[must_use]
     pub fn split(&mut self, at: usize) -> Self {
         let before: String = self.graphemes().take(at).collect();
         let after: String = self.graphemes().skip(at).collect();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,7 +34,7 @@ pub fn expand_tilde(s: &str) -> String {
     if !s.starts_with('~') {
         return s.to_string();
     }
-    s.replace("~", env!("HOME"))
+    s.replace('~', env!("HOME"))
 }
 
 #[must_use]


### PR DESCRIPTION
Last time I worked on `bo`, I was using `rustc 1.53` and CI is now on `rustc 1.60`. Some new clippy violations must be fixed.