### PR TITLE
Host the whole coverage report on s3 for public read

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,5 +72,5 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
-        SOURCE_DIR: ${{ steps.coverage.outputs.report }}/badges
+        SOURCE_DIR: ${{ steps.coverage.outputs.report }}
         DEST_DIR: 'bo'


### PR DESCRIPTION
The generated HTML files will be directly accessible, as the s3 bucket is configured for public static website hosting.