### PR TITLE
Enable autocompletion based on command user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Features
+- Implement autocompletion based on user provided commands (ex: `:deb<TAB>` autocompletes to `:debug`). Multiple completion suggestions can be cycled through, accepted or ignored.
+
 ## [0.3.3] - 2022/05/01
 
 ### Features

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,3 +9,17 @@ pub const NEW: &str = "new";
 pub const SAVE: &str = "w";
 pub const SAVE_AND_QUIT: &str = "wq";
 pub const DEBUG: &str = "debug";
+
+pub const ALL_COMMANDS: [&str; 11] = [
+    QUIT,
+    FORCE_QUIT,
+    LINE_NUMBERS,
+    STATS,
+    HELP,
+    OPEN,
+    OPEN_SHORT,
+    NEW,
+    SAVE,
+    SAVE_AND_QUIT,
+    DEBUG,
+];


### PR DESCRIPTION
This PR enables autocompletion on the user-provided command.

If only one command suggestion is found, it will be automatically selected.
Else, the `command_suggestions` vector will be populated with the possible
commands, and subsequent `<Tab>` presses will allow the user to navigate through the suggestions. `<Enter>` will accept the suggestion and run it, whereas any other keypress will ignore the suggestions and update the command buffer.